### PR TITLE
add `isntnt` as a recommended library

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ We recommend using [Muban](https://github.com/mediamonks/muban) for Server Rende
 
 #### TypeScript
  * [ts-essentials](https://www.npmjs.com/package/ts-essentials) - TypeScript utilities
+ * [isntnt](https://www.npmjs.com/package/isntnt) - Composable TypeScript predicate
 
 #### React
  * [Formik](https://jaredpalmer.com/formik/) - Forms

--- a/README.md
+++ b/README.md
@@ -376,8 +376,8 @@ makes integration into CMS systems, like
 - [Yup](https://github.com/jquense/yup) - Form validation
 
 #### TypeScript
- * [isntnt](https://www.npmjs.com/package/isntnt) - Composable TypeScript predicate
- * [ts-essentials](https://www.npmjs.com/package/ts-essentials) - TypeScript utilities
+ - [isntnt](https://www.npmjs.com/package/isntnt) - Composable TypeScript predicate
+ - [ts-essentials](https://www.npmjs.com/package/ts-essentials) - TypeScript utilities
 
 #### React
 


### PR DESCRIPTION
`isntnt` is an incredibly useful library built by ours truly @mmnathan and it is also included in our `standard` CRA template.

It deserves to be on the recommended library list.