### PR TITLE
Casing update: Treat abbreviations as words

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ underscore.
 
 #### Abbreviations
 
-Abbreviations should be treated as words, which means only the first character will be capitalized for camelCase and PascalCase.
+Abbreviations should be treated as words, which means only the first character will be capitalized
+for camelCase and PascalCase.
 ```
 const jsonApiSdkUrl = new JsonApiSdkUrl();
 ``` 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ underscore.
 
 **kabab-case** Only use lower case characters, individual words must be separated with a dash.
 
-#### Abbreviations
+#### Abbreviations and Acronyms
 
 Abbreviations should be treated as words, which means only the first character will be capitalized
 for camelCase and PascalCase.

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ developers won't have to remember whether you shortened a word like _qualified_ 
 
 Abbreviations that are part of the HTML, CSS and/or JavaScript API are allowed, like:
 
-- `URL` for Uniform Resource Locator
-- `URI` for Uniform Resource Identifier
+- `url` for Uniform Resource Locator
+- `uri` for Uniform Resource Identifier
 - `src` for source
-- `DOM` for Document Object Model
+- `dom` for Document Object Model
 - `img` for image
 
 You should only use these abbreviations within the same context. So only use `img` if you refer to
@@ -165,6 +165,13 @@ underscore.
 #### CSS Class names
 
 **kabab-case** Only use lower case characters, individual words must be separated with a dash.
+
+#### Abbreviations
+
+Abbreviations should be treated as words, which means only the first character will be capitalized for camelCase and PascalCase.
+```
+const jsonApiSdkUrl = new JsonApiSdkUrl();
+``` 
 
 ### File names
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ underscore.
 
 #### Abbreviations and Acronyms
 
-Abbreviations should be treated as words, which means only the first character will be capitalized
+Abbreviations and acronyms should be treated as words, which means only the first character will be capitalized
 for camelCase and PascalCase.
 ```
 const jsonApiSdkUrl = new JsonApiSdkUrl();

--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -19,21 +19,21 @@ const typeScriptSettings = {
       'error',
       {
         selector: 'default',
-        format: ['camelCase'],
+        format: ['strictCamelCase'],
         leadingUnderscore: 'forbid',
         trailingUnderscore: 'forbid',
       },
       {
         selector: 'typeLike',
-        format: ['PascalCase'],
+        format: ['StrictPascalCase'],
       },
       {
         selector: 'variable',
-        format: ['camelCase', 'UPPER_CASE'],
+        format: ['strictCamelCase', 'UPPER_CASE'],
       },
       {
         selector: 'enumMember',
-        format: ['PascalCase'],
+        format: ['StrictPascalCase'],
       },
     ],
     '@typescript-eslint/no-empty-function': 'error',
@@ -191,27 +191,27 @@ module.exports = {
           'error',
           {
             selector: 'default',
-            format: ['camelCase'],
+            format: ['strictCamelCase'],
             leadingUnderscore: 'forbid',
             trailingUnderscore: 'forbid',
           },
           {
             selector: 'typeLike',
-            format: ['PascalCase'],
+            format: ['StrictPascalCase'],
           },
           {
             selector: 'variable',
             // Exception for FunctionComponents
-            format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+            format: ['strictCamelCase', 'StrictPascalCase', 'UPPER_CASE'],
           },
           {
             selector: 'function',
             // Exception for FunctionComponents
-            format: ['camelCase', 'PascalCase'],
+            format: ['strictCamelCase', 'StrictPascalCase'],
           },
           {
             selector: 'enumMember',
-            format: ['PascalCase'],
+            format: ['StrictPascalCase'],
           },
         ],
       },


### PR DESCRIPTION
This PR sets the eslint configuration more strict when it comes to the casing of abbreviations. Abbreviations will be treated as words, which means only the first character will be capitalized for camelCase and PascalCase.
```
const jsonApiSdkUrl = new JsonApiSdkUrl();
``` 

See #9 
See https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md