### PR TITLE
fix `prettier` peer dependency version

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react-hooks": ">= 4.2",
     "eslint-plugin-unicorn": ">= 18",
     "eslint-plugin-vue": "7.0.0",
-    "prettier": "> 2",
+    "prettier": ">= 2",
     "typescript": ">= 3.3"
   },
   "dependencies": {


### PR DESCRIPTION
It seems that `npm` treats the **> 2** version specifier as _above the major version 2_ ignoring the _minor_ and _patch_ specifiers.

So it only matches on versions, whose _major_ specifier is above **2**,  e.g. **3**. This means, that currently it fails to match the [latest version](https://www.npmjs.com/package/prettier/v/2.2.1) of **2.2.1**.

Changing the version specifier to also _include_ major version **2** fixes this (this is what the PR changes).
Interestingly, changing **> 2** to **> 2.0.0** also works, as now it also checks the _minor_ and _patch_ specifiers, but of course excludes the version **2.0.0**.